### PR TITLE
updated box.json file

### DIFF
--- a/box.json
+++ b/box.json
@@ -3,7 +3,7 @@
     "version":"1.2.1",
     "author":"Pixl8 Interactive",
     "createPackageDirectory":true,
-    "packageDirectory":"application/extensions/preside-ext-zabbix",
+    "directory":"application/extensions",
     "homepage":"https://github.com/pixl8/preside-ext-zabbix",
     "documentation":"https://github.com/pixl8/preside-ext-zabbix",
     "repository":{


### PR DESCRIPTION
packageDirectory should not contain a path but a directory name. the purpose of it is to overwrite the slug - which is the default package directory name. if the package should be installed in a specific location, the directory property is the correct one to use.
